### PR TITLE
Improve use of anyascii

### DIFF
--- a/xword_dl/downloader/amuselabsdownloader.py
+++ b/xword_dl/downloader/amuselabsdownloader.py
@@ -225,7 +225,7 @@ class AmuseLabsDownloader(BaseDownloader):
                     solution += cell[0]
                     fill += '-'
                     rebus_board.append(rebus_index + 1)
-                    rebus_table += '{:2d}:{};'.format(rebus_index, unidecode(cell))
+                    rebus_table += '{:2d}:{};'.format(rebus_index, latinize(cell))
                     rebus_index += 1
 
         puzzle.solution = solution

--- a/xword_dl/downloader/newyorktimesdownloader.py
+++ b/xword_dl/downloader/newyorktimesdownloader.py
@@ -5,7 +5,7 @@ import puz
 import requests
 
 from .basedownloader import BaseDownloader
-from ..util import XWordDLException, join_bylines, update_config_file, unidecode
+from ..util import XWordDLException, join_bylines, latinize, update_config_file
 
 class NewYorkTimesDownloader(BaseDownloader):
     command = 'nyt'
@@ -145,7 +145,7 @@ class NewYorkTimesDownloader(BaseDownloader):
                 rebus_board.append(0)
             else:
                 try:
-                    suitable_answer = unidecode(square.get('answer') or 
+                    suitable_answer = latinize(square.get('answer') or
                                         square['moreAnswers']['valid'][0])
                 except (IndexError, KeyError):
                     raise XWordDLException('Unable to parse puzzle JSON. Possibly something .puz incompatible')


### PR DESCRIPTION
Because anyascii caches lookups on a module level and iterates by codepoint anyway, it's perfectly efficient to filter out latin-1 codepoints and pass the rest through anyascii.